### PR TITLE
Added a warning to host_demux.py when no xdt value is provided.

### DIFF
--- a/acq400_hapi/acq400.py
+++ b/acq400_hapi/acq400.py
@@ -473,7 +473,7 @@ class Acq400:
     def set_sync_routing_slave(self):
         self.set_sync_routing_master()
         self.s0.SIG_SRC_CLK_1 = "HDMI"
-        self.s0.SIG_SRC_TRG_0 = "HDMI_TRG"
+        self.s0.SIG_SRC_TRG_0 = "HDMI"
 
     def set_sync_routing(self, role):
         # deprecated

--- a/user_apps/analysis/cs_demux.py
+++ b/user_apps/analysis/cs_demux.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+"""
+A python script to demux the data from the corescan system.
+
+The data is supposed to come out in the following way:
+
+CH01 .. CH02 .. CH03 .. CH04 .. INDEX .. FACET .. COUNT
+short   short   short   short   long     long     long
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import argparse
+
+def find_zero_index(args):
+    # This function finds the first 0xaa55 short value in the data and then
+    # uses this position to check the index before this event sample and the
+    # index after this event sample and checks the latter is one greater
+    # than the former. If the values do not increment then go to the next
+    # event sample
+
+    data = np.fromfile(args.df, dtype=np.uint32)
+    for short_pos, short_val in enumerate(data):
+        short = format(short_val, '08x')
+        print "short_val = ", short
+        if short_val == 0xaa55f154:
+            # if count < 4:
+            #     continue
+            # Check current index
+            first_es_position = short_pos
+            print "first es position found @ ", first_es_position
+            break
+
+    # loop over all the event samples. Look at the "index" value before and
+    # after and check they have incremented.
+    #for pos, f_short_in_es in enumerate(data[first_es_position:-1:((10*8192)+(9+(10*3)))]):
+    counter = 0
+    for pos, f_short_in_es in enumerate(data):
+        if pos < first_es_position:
+            continue
+        if counter % (49212 + 24) == 0: # TODO: Ask Scott why this is
+
+            #print "counter - ", counter, " value = ", f_short_in_es
+            print "DEBUG: pre = ", data[pos - 3], " post = ", data[pos + 27]
+            counter += 1
+            if data[pos - 3] + 1 == data[pos + 27]:
+                zero_index_long_pos = pos
+                print "zisp = ", zero_index_long_pos
+                return zero_index_long_pos
+        else:
+            counter += 1
+            continue
+
+
+def demux_data(args, zero_index):
+    data = []
+    chunk = [1]
+    count = 0
+
+    with open(args.df, "rb") as f:
+        # throw away all data before the "zeroth" index (the first es)
+        chunk = np.fromfile(f, dtype=np.int32, count=int(zero_index))
+
+        while len(chunk) != 0: # if chunk size is zero we have run out of data
+
+            #throw away es
+            if count % 8202 == 0: # Should be 8202?
+                chunk = np.fromfile(f, dtype=np.int32, count=24) # strip es
+                print ""
+                for item in chunk:
+
+                    print "{}".format(item, '08x')
+
+            # collect data into a new list
+            chunk = np.fromfile(f, dtype=np.int16, count=4)
+            data.extend(chunk)
+            chunk = np.fromfile(f, dtype=np.int32, count=4)
+            data.extend(chunk)
+            #print "chunk = ", chunk
+            count += 1
+        #print "data = ", data
+        f.close() # close file when all the data has been loaded.
+    return data
+
+
+def save_data(args, data):
+    np.tofile("test_file", data)
+    return None
+
+
+def plot_data(args, data):
+    # plot all the data in order (not stacked)
+
+    # f, plots = plt.subplots(8, 1, sharex=True)
+
+    f, plots = plt.subplots(8, 1)
+    for sp in range(0,8):
+        plots[sp].plot(data[sp:-1:8])
+
+        #plt.subplot((sp*100)+11)
+        #plt.plot(data[sp-1:-1:8])
+
+    # plt.plot(data[7:-1:8])
+
+    # plot all the data in stacks (one stack on top of the other)
+    # for sp in range(0,6):
+    #     plt.subplot(sp)
+    #     for ssp in range(0:len(data)-1:8192): # loop over data in 8192 blocks
+    #         plt.plot(data[ssp:ssp+8192-1:7]) # plot in blocks of 8192
+    plt.show()
+    return None
+
+
+def run_main():
+    parser = argparse.ArgumentParser(description='cs demux')
+    parser.add_argument('--plot', default=1, type=int, help="Plot data")
+    parser.add_argument('--save', default=0, type=int, help="Save data")
+    parser.add_argument('--tl', default=8202, type=int, help='transient length')
+    parser.add_argument('--df', default="./shot_data", type=str, help="Name of"
+                                                                    "data file")
+
+    args = parser.parse_args()
+
+    # zero_index should be the index of the first event sample where the
+    # system value index increments over the event sample.
+    zero_index = find_zero_index(args)
+
+    # data = long list of CH01, CH02, CH03, CH04, INDEX, FACET, USEC
+    data = demux_data(args, zero_index)
+    if args.plot == 1:
+        plot_data(args, data)
+    if args.save == 1:
+        save_data(args, data)
+
+if __name__ == '__main__':
+    run_main()

--- a/user_apps/analysis/host_demux.py
+++ b/user_apps/analysis/host_demux.py
@@ -37,7 +37,7 @@ example usage::
     # plot data from LLC, 128 channels, show one "channel" from each site.
     # 97 was actually the LSB of TLATCH.
 
-usage:: 
+usage::
 
     host_demux.py [-h] [--nchan NCHAN] [--nblks NBLKS] [--save SAVE]
                      [--src SRC] [--pchan PCHAN]
@@ -58,7 +58,7 @@ optional arguments:
   --egu EGU      plot egu (V vs s)
   --xdt XDT      0: use interval from UUT, else specify interval
 
-    
+
 
 """
 
@@ -89,7 +89,7 @@ def create_npdata(args, nblk, nchn):
            channels.append(np.zeros(16, dtype=np.int16))
     # print "length of data = ", len(total_data)
     # print "npdata = ", npdata
-    return channels 
+    return channels
 
 
 def make_cycle_list(args):
@@ -136,10 +136,10 @@ def read_data(args):
         print(f)
     if NCHAN % 3 == 0:
         print("collect in groups of 3 to keep alignment")
-        GROUP = 3 
+        GROUP = 3
     else:
         GROUP = 1
-    
+
 
     if NSAM == 0:
         NSAM = GROUP*os.path.getsize(data_files[0])/WSIZE/NCHAN
@@ -151,7 +151,7 @@ def read_data(args):
         data_files = [ data_files[i] for i in range(0,NBLK) ]
 
     print("NBLK {} NBLK/GROUP {} NCHAN {}".format(NBLK, NBLK/GROUP, NCHAN))
-  
+
     raw_channels = create_npdata(args, NBLK/GROUP, NCHAN)
     blocks = 0
     i0 = 0
@@ -171,7 +171,7 @@ def read_data(args):
             iblock += 1
             if iblock < GROUP:
                 continue
-                
+
             i1 = i0 + NSAM
             for ch in range(NCHAN):
                 if channel_required(args, ch):
@@ -185,7 +185,7 @@ def read_data(args):
     print "length of data[0] = ", len(raw_channels[0])
     print "length of data[1] = ", len(raw_channels[1])
     return raw_channels
-   
+
 def read_data_file(args):
     NCHAN = args.nchan
     data = np.fromfile(args.src, dtype=np.int16)
@@ -194,7 +194,7 @@ def read_data_file(args):
     for ch in range(NCHAN):
         if channel_required(args, ch):
             raw_channels[ch] = data[ch::NCHAN]
-    
+
     return raw_channels
 
 def save_data(args, raw_channels):
@@ -204,14 +204,14 @@ def save_data(args, raw_channels):
         channel.tofile(data_file, '')
 
     return raw_channels
-    
+
 
 def plot_data(args, raw_channels):
     client = pykst.Client("NumpyVector")
     llen = len(raw_channels[0])
     if args.egu == 1:
         if args.xdt == 0:
-            print "##### WARNING ##### NO CLOCK RATE PROVIDED. TIME SCALE _WILL_ BE INNACURATE."
+            print "WARNING ##### NO CLOCK RATE PROVIDED. TIME SCALE measured by system."
             raw_input("Please press enter if you want to continue with innacurate time base.")
             time1 = float(args.the_uut.s0.SIG_CLK_S1_FREQ.split(" ")[-1])
             xdata = np.linspace(0, llen/time1, num=llen)
@@ -245,7 +245,7 @@ def plot_data(args, raw_channels):
         c1 = client.new_curve(V1, V2)
         p1 = client.new_plot()
         p1.set_left_label(yu1)
-        p1.set_bottom_label(xu)  
+        p1.set_bottom_label(xu)
         p1.add(c1)
 
 
@@ -268,8 +268,8 @@ def make_pc_list(args):
         x2 = args.nchan+1 if lr[1] == '' else int(lr[1])+1
         return list(range(x1, x2))
     else:
-        return args.pchan.split(',') 
-    
+        return args.pchan.split(',')
+
 def run_main():
     parser = argparse.ArgumentParser(description='host demux, host side data handling')
     parser.add_argument('--nchan', type=int, default=32)
@@ -287,7 +287,7 @@ def run_main():
         print("uutroot {}".format(args.uutroot))
     elif os.path.isfile(args.src):
         args.uutroot = "{}".format(os.path.dirname(args.src))
-    if args.save != None: 
+    if args.save != None:
         if args.save.startswith("/"):
             args.saveroot = args.save
         else:


### PR DESCRIPTION
	modified:   host_demux.py
        Added a hard warning to host_demux.py
        for the case where no clock is provided
        by the user. The reason for this is that
        the script will ask the system in question
        for its sample clock rate. This is not always
        completely accurate and should not be used for
        data comparison across systems.