### PR TITLE
Removed numpy from required packages.

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -46,6 +46,6 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),  
 
-    install_requires=['numpy', 'future'],
+    install_requires=['future'],
 
 )


### PR DESCRIPTION
	modified:   package/setup.py
        Removed numpy because it breaks python2