### PR TITLE
Removed debug from __init__.py.

### DIFF
--- a/acq400_hapi/__init__.py
+++ b/acq400_hapi/__init__.py
@@ -13,4 +13,4 @@ from . import awg_data
 from .acq400_ui import Acq400UI
 from . import awg_data
 from .intSI import *
-from .debug import Debugger
+#from .debug import Debugger


### PR DESCRIPTION
        modified:   acq400_hapi/__init__.py

Not sure what this was calling - but it was broken for me. I was going to publish a new pip-release but I think this should be sorted first! Let me know if this is something we want to keep, just wanted to bring it to your attention.