### PR TITLE
Fix Acq400.factory()

### DIFF
--- a/acq400_hapi/acq400.py
+++ b/acq400_hapi/acq400.py
@@ -1309,12 +1309,9 @@ def factory(_uut):
     ''' instantiate s0. deduce what sort of ACQ400 this is and invoke the appropriate subclass
     '''
     try:
-        cached = Acq400.uuts[_uut]
-        return cached
+        s0 = Acq400.uuts[_uut]['svc']['s0']
     except KeyError:
-        pass
-    
-    s0 = netclient.Siteclient(_uut, AcqPorts.SITE0)
+        s0 = netclient.Siteclient(_uut, AcqPorts.SITE0)
     
     if not s0.MODEL.startswith("acq2106"):
         return Acq400(_uut, s0)


### PR DESCRIPTION
factory() was returning a cached dictionary from Acq400.uuts[] if it existed.
However, the result should have been an instance of Acq400, Acq2106, etc.

I'm not sure if this is the best fix, but we've tested it and it does seem to work.