### PR TITLE
Initialization of cal_eslo[] and cal_eoff[] in fetch_all_calibration

### DIFF
--- a/acq400_hapi/acq400.py
+++ b/acq400_hapi/acq400.py
@@ -521,6 +521,8 @@ class Acq400:
 
     def fetch_all_calibration(self):
 #        print("Fetching calibration data")
+        self.cal_eslo = [0.]
+        self.cal_eoff = [0.]
         for m in (self.modules[int(c)] for c in self.get_aggregator_sites()):
             self.cal_eslo.extend(m.AI_CAL_ESLO.split(' ')[3:])
             self.cal_eoff.extend(m.AI_CAL_EOFF.split(' ')[3:])


### PR DESCRIPTION
Repeated calls to the function with _different_ gains (using the same UUT object), gives back the wrong coefficients.

By initializing the cal_eslo[] and cal_eoff[] lists to [0.], we ensure that the return coefficients corresponds to the selected gain.