### PR TITLE
Move pyplot import inside of plot_data()

### DIFF
--- a/acq400_hapi/shotcontrol.py
+++ b/acq400_hapi/shotcontrol.py
@@ -4,11 +4,6 @@ import time
 import os
 import errno
 
-try:
-    import matplotlib.pyplot as plt
-except Exception as e:
-    plt = e
-
 def wait_for_state(uut, state, timeout=0):
     UUTS = [uut]
     time0 = 0
@@ -222,6 +217,11 @@ class ShotController:
 class ShotControllerWithDataHandler(ShotController):
        
     def plot_data(self, args, plot_data, chx, ncol, nchan, nsam):
+        try:
+            import matplotlib.pyplot as plt
+        except Exception as e:
+            plt = e
+
         if isinstance(plt, Exception):
             print("Sorry, plotting not available")
             return        


### PR DESCRIPTION
This will suppress warnings from X11/GDK when importing acq400_hapi in headless environments

The errors are things like:
```
Unable to init server: Could not connect: Connection refused
Unable to init server: Could not connect: Connection refused

(.:790690): Gdk-CRITICAL **: 23:38:55.485: gdk_cursor_new_for_display: assertion 'GDK_IS_DISPLAY (display)' failed
```