### PR TITLE
run-stream-ramdisk: default to not overwrite

### DIFF
--- a/scripts/run-stream-ramdisk
+++ b/scripts/run-stream-ramdisk
@@ -2,7 +2,7 @@
 
 devnum=${1:-0} 
 nbuffers=${2:-1024}
-overwrite=${3:-1} # 1 = overwite 0 = dont
+overwrite=${3:-0} # 1 = overwite 0 = dont
 
 if [ !  -e ../AFHBA404 ]; then
 	echo "ERROR: did not find ../AFHBA404"


### PR DESCRIPTION
Otherwise, when run with latest head from AFHBA project, will only ever write 1 cycle (66 1MiB) files, over and over. Not a good default!

Tested against latest AFHBA. Works fine.