### PR TITLE
set.pythonpath: add missing "export"

### DIFF
--- a/set.pythonpath
+++ b/set.pythonpath
@@ -1,2 +1,1 @@
-echo PYTHONPATH=$PWD > /etc/profile.d/acq400_hapi.sh
-
+echo export PYTHONPATH=$PWD > /etc/profile.d/acq400_hapi.sh


### PR DESCRIPTION
* Fixes PYTHONPATH env var not actually being set