### PR TITLE
Remove all scripts that set PYTHONPATH

### DIFF
--- a/SETPYTHONPATH.BAT
+++ b/SETPYTHONPATH.BAT
@@ -1,1 +1,0 @@
-setx PYTHONPATH %cd%

--- a/set.pythonpath
+++ b/set.pythonpath
@@ -1,1 +1,0 @@
-echo export PYTHONPATH=$PWD > /etc/profile.d/acq400_hapi.sh

--- a/setpath
+++ b/setpath
@@ -1,2 +1,0 @@
-export PYTHONPATH=$PWD
-

--- a/setpath2
+++ b/setpath2
@@ -1,6 +1,0 @@
-#!/bin/bash
-# set python path from somewhere else
-# example use:
-# source ~/PROJECTS/acq400_hapi/setpath2
-export PYTHONPATH=$(dirname $(realpath "${BASH_SOURCE[0]}" ))
-


### PR DESCRIPTION
I'm pretty sure none of these 4 scripts are required any more. All they probably do now is cause confusion.