### PR TITLE
Update acq400.py

### DIFF
--- a/acq400_hapi/acq400.py
+++ b/acq400_hapi/acq400.py
@@ -516,7 +516,7 @@ class Acq400:
 
     def close(self):
         """Closes uut connection gracefully"""
-        self.statmon.quit_reqested = True
+        self.statmon.quit_requested = True
 
         try:
             self.statmon.logclient.close()


### PR DESCRIPTION
acq400.close() method creating new attribute self.quit_reqested instead of updating self.quit_requested. OSErrors pop up as st_monitor() does not see the updated value of self.quit_requested and continues the while loop not knowing that the dtacq unit has been closed.